### PR TITLE
Writeback before render

### DIFF
--- a/client_code/main/_primitives.py
+++ b/client_code/main/_primitives.py
@@ -10,6 +10,7 @@ from functools import partial, wraps
 import anvil
 from anvil import Component
 
+from .._internal.core import untrack
 from .._internal.signal import create_effect, create_memo, create_root
 from ._constants import MISSING
 from ._utils import CacheDict, noop
@@ -274,6 +275,9 @@ def writeback(component, prop, reactive_or_getter, attr_or_effect=None, events=(
     REACTIVE_COMPONENT.get(component).writebacks.append(
         lambda component: create_effect(render)
     )
+    with untrack():
+        # we do this now to avoid show events causing renders that animate
+        return render()
 
 
 def bind(component, prop, reactive_or_getter, attr=MISSING):


### PR DESCRIPTION
This PR might be controversial

When a writeback occurs we currently wait until the component is added to the page before firing it
But in edge cases we see some animations/transitions because we are setting properties when the component is already on the screen.

This PR adds an implementation that runs the writeback code in untracked mode straight away
this causes the component to be in the correct state when it is added to the page
and we re-run the writebacks when the component is added to the page

This will cause writebacks to run twice the first time the component is loaded


@meatballs in your demo app - you'll see the difference if you click a row
with this PR you don't see the dropdown transition on the label
